### PR TITLE
235_LCA_done

### DIFF
--- a/1_Medium/235_lowest_ancestor2.py
+++ b/1_Medium/235_lowest_ancestor2.py
@@ -6,17 +6,34 @@ p != q
 p and q will exist in the BST.
 """
 
-# Definition for a binary tree node.
+## Key thing to recall is that a BST is sorted. Left of a node than node and Right of a node is > node
+#### Based on root node
+
+# Definition for a binary tree node
 class TreeNode:
     def __init__(self, x):
         self.val = x
         self.left = None
         self.right = None
 
+# O(h) runtime complexity given that only one node is being appraised at each level. O(1) space complexity
+# as no new variables, lists/queues/stacks are created to help iterate through the tree
 class Solution:
     def lowestCommonAncestor(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> 'TreeNode':
-        
+
         current = root
+
+        while current:
+            # if both values fall to right of current node
+            if p.val > current.val and q.val > current.val:
+                current = current.right
+            # if both values fall to left of current node
+            elif p.val < current.val and q.val < current.val:
+                current = current.left
+            # find a situation where the current node is either p or q or the last node before the nodes split off
+            elif min(p.val, q.val) <= current.val and max(p.val, q.val) >= current.val:
+                return current.val
+            
 
 if __name__ == "__main__":
 
@@ -33,6 +50,8 @@ if __name__ == "__main__":
     root.right = TreeNode(8)
     root.right.left = TreeNode(7)
     root.right.right = TreeNode(9)
+    q = root.right.right
+
 
     print(solution.lowestCommonAncestor(root,p,q))
 


### PR DESCRIPTION
This solution finds the Lowest Common Ancestor (LCA) of two nodes in a Binary Search Tree (BST) by leveraging the BST's inherent ordering properties. Starting from the root, the algorithm traverses the tree iteratively: if both p and q are greater than the current node, we move to the right subtree; if both are smaller, we move to the left. The first node where the values of p and q split (i.e., one on each side or one equal to the current node) is the LCA.
Time and Space Complexity

Time Complexity: O(h), where h is the height of the tree. In a balanced BST, this is O(log n); in the worst case (skewed tree), it can be O(n).

Space Complexity: O(1), since the solution uses constant space with an iterative approach (no recursion stack)