### PR TITLE
104_MaxBinaryDepth

### DIFF
--- a/0_Easy/104_maximum_depth_binary_tree.py
+++ b/0_Easy/104_maximum_depth_binary_tree.py
@@ -1,0 +1,67 @@
+from typing import Optional
+"""
+A binary tree's maximum depth is the number of nodes along the longest path from the root node down to the farthest leaf node.
+
+"""
+
+# Definition for a binary tree node.
+class TreeNode:
+    def __init__(self, val=0, left=None, right=None):
+        self.val = val
+        self.left = left
+        self.right = right
+
+# BFS
+# O(n) time and O(n) space complexity
+class Solution:
+    def maxDepth(self, root: Optional[TreeNode]) -> int:
+        # Set the layer of the binary tree to zero initially
+        level = 0
+
+        # Check if there are any TreeNodes in root
+        if not root:
+            return level
+
+        # Set current layer to root
+        current = {}
+        current[level] = [root]
+
+        # While there are still TreeNodes in a layer...
+        while len(current[level]) > 0:
+
+            # Set up new layer
+            level += 1
+            current[level] = []
+
+            # Iterate through old layer and see if there are any nodes 1 layer down
+            for x in current[level-1]:
+                if x.left is not None:
+                    current[level].append(x.left)
+                if x.right is not None:
+                    current[level].append(x.right)
+        
+        return level
+
+# DFS
+# O(n) time and O(n) space complexity    
+class Solution2:
+    def maxDepth(self, root: Optional[TreeNode]) -> int:
+        if not root:
+            return 0
+        
+        left_depth = self.maxDepth(root.left)
+        right_depth = self.maxDepth(root.right)
+        
+        # iterate through all nodes return which pathway returns max depth
+        return 1 + max(left_depth, right_depth)
+                    
+
+
+    
+if __name__ == "__main__":
+
+    solution = Solution()
+
+    root = TreeNode(val = 0, left = TreeNode(val=1, left = TreeNode(val=3, left = TreeNode(val=4))), right = TreeNode(val = 2))
+
+    print(solution.maxDepth(root))


### PR DESCRIPTION
This solution computes the maximum depth of a binary tree — the number of nodes along the longest path from the root node to the farthest leaf. Two strategies are implemented: a breadth-first search (BFS) approach and a depth-first search (DFS) approach, each exploring the structure of the tree differently while achieving the same result.

The BFS-based implementation uses a level-by-level traversal. A dictionary is used to store nodes at each level, incrementing the level count as long as there are nodes present at the next depth. While slightly unconventional compared to using a queue, this method effectively simulates layer-based expansion and clearly illustrates how the tree depth increases. Time and space complexity are both O(n), where n is the number of nodes in the tree, since each node is visited once and temporarily stored.

The DFS-based implementation applies a recursive strategy, where the function returns 1 plus the maximum depth of the left or right subtree. This method naturally leverages the recursive structure of the tree and concisely expresses the depth calculation in a single return statement. It also runs in O(n) time, with O(n) space used by the call stack in the worst case (e.g., a skewed tree).